### PR TITLE
fixes the problem where fields are being missed when u are using the …

### DIFF
--- a/src/HasConditionalContainer.php
+++ b/src/HasConditionalContainer.php
@@ -141,7 +141,8 @@ trait HasConditionalContainer
 
         }
 
-        $allFields = $this->fields($request);
+        $method = parent::fieldsMethod($request);
+        $allFields = $this->{$method}($request);
         $containers = $this->findAllContainers($allFields);
         $expressionsMap = $containers->flatMap->expressions->map(function ($expression) {
             return is_callable($expression) ? $expression() : $expression;

--- a/src/HasConditionalContainer.php
+++ b/src/HasConditionalContainer.php
@@ -141,7 +141,7 @@ trait HasConditionalContainer
 
         }
 
-        $method = parent::fieldsMethod($request);
+        $method = $this->fieldsMethod($request);
         $allFields = $this->{$method}($request);
         $containers = $this->findAllContainers($allFields);
         $expressionsMap = $containers->flatMap->expressions->map(function ($expression) {


### PR DESCRIPTION
Hey, 

First, Very nice package! 

I'm using a Resource with the custom field functions `fieldsForDetail`, `fieldsForIndex` and the normal `fields` function.

### Error
Now I did come across a weird javascript error on the Detail page:

![Schermafbeelding 2020-05-13 om 15 25 46](https://user-images.githubusercontent.com/6905655/81818210-07cb0000-952e-11ea-92ce-1f97b4656918.png)

### Information
I'm using the ConditionalContainer around a Flexible field on the Edit and Create pages:

```php
public function contentFields() {
    $collection = new Collection();
    $collection->push($this->presetSelect());

    Collection::make($this->presets)
        ->each(function ($preset) use (&$collection) {
            $collection->push(
                ConditionalContainer::make([
                    Flexible::make('', 'content')
                        ->preset($preset)
                ])->if('type = ' . $preset::$name)
            );
        });

    return $collection;
}
```

This function wil be used as content for a Panel field within the `fields` function.

```php
Panel::make('Content', $this->contentFields())
```

This works fine on v1.1.6. The error occurs on the detail page. For the detail page I use the custom `fieldsForDetail` function. Within this function I'm using the same setup as for the edit and create page:

```php
Panel::make('Content', $this->contentFieldsForDetail()),
```

```php
public function contentFieldsForDetail()
{
    return [
        Text::make('Type', 'type'),

        Flexible::make('', 'content')
            ->preset($this->activePreset())
    ];
}
```

### Conclusion
The Error says `Cannot set property 'fields' of undefined`. So I'm guessing the script misses something. 

### My Solution
So my thought process was that the fields that were given to the detail page were not the right ones. Thats why I thought it would be inside the `HasConditionalContainer` trait. Because I'm using the ConditionalContainer inside the create and edit page but not on the Detail page.

I found the `availableFields` function and saw that u already excluded the ConditionalContainers for the Index route but couldn't find an exception for the Detail page. So i guessed that it would come to the end of this function.

Thats where i found the `$allFields = $this->fields($request);` line. I knew that the Resource base class from Nova uses a method to find the right fields method. So i tried to implement this as seen in the commit 12b162d. 

And that fixed my problem and the detail page showed up again.

### Personal touch
I do not know if this breaks anything. It works within my project and it fixed my problem so I thought I'd send a PR so you can see my changes and change it the way you like.

With kind regards,

Menno Tempelaar

