### PR TITLE
Fixed the ability to update a resource. Related to #37

### DIFF
--- a/src/ConditionalContainer.php
+++ b/src/ConditionalContainer.php
@@ -290,7 +290,8 @@ class ConditionalContainer extends Field
                     !blank($field->attribute) &&
                     !$field->isReadonly($request) &&
                     !$field instanceof RelatableField &&
-                    !$field instanceof \Whitecube\NovaFlexibleContent\Flexible) {
+                    !$field instanceof \Whitecube\NovaFlexibleContent\Flexible &&
+                    !$field instanceof \DigitalCreative\ConditionalContainer\ConditionalContainer) {
 
                     $resource->setAttribute($field->attribute, $field->value);
 


### PR DESCRIPTION
When you try to update a resource, the conditional field is added to the update query, resulting in an error.

With this verification, it avoids adding these conditional fields to the update.

Related to issue #37 