### PR TITLE
Add support for BelongsToManyField inside of a ConditionalContainer

### DIFF
--- a/src/ConditionalContainer.php
+++ b/src/ConditionalContainer.php
@@ -291,6 +291,7 @@ class ConditionalContainer extends Field
                     !$field->isReadonly($request) &&
                     !$field instanceof RelatableField &&
                     !$field instanceof \Whitecube\NovaFlexibleContent\Flexible &&
+                    !$field instanceof \Benjacho\BelongsToManyField\BelongsToManyField &&
                     !$field instanceof \DigitalCreative\ConditionalContainer\ConditionalContainer) {
 
                     $resource->setAttribute($field->attribute, $field->value);


### PR DESCRIPTION
Hi,

This should solve nr 2 in Issue #29. This makes the BelongsToManyField work inside a ConditionalContainer.
I added the BelongsToManyField as an exception in resolveDependencyFieldUsingRequest.