### PR TITLE
Check if field is shown on update

### DIFF
--- a/src/ConditionalContainer.php
+++ b/src/ConditionalContainer.php
@@ -305,7 +305,6 @@ class ConditionalContainer extends Field
             foreach ($this->fields as $field) {
 
                 if ($field instanceof Field &&
-                    $field->isShownOnUpdate($request, $request) &&
                     !blank($field->attribute) &&
                     !$field->isReadonly($request) &&
                     !$field instanceof File &&

--- a/src/ConditionalContainer.php
+++ b/src/ConditionalContainer.php
@@ -305,6 +305,7 @@ class ConditionalContainer extends Field
             foreach ($this->fields as $field) {
 
                 if ($field instanceof Field &&
+                    $field->isShownOnUpdate($request, $request) &&
                     !blank($field->attribute) &&
                     !$field->isReadonly($request) &&
                     !$field instanceof File &&

--- a/src/HasConditionalContainer.php
+++ b/src/HasConditionalContainer.php
@@ -105,7 +105,9 @@ trait HasConditionalContainer
         }
 
         if ($controller instanceof CreationFieldController ||
-            $controller instanceof UpdateFieldController) {
+            $controller instanceof UpdateFieldController ||
+            $controller instanceof ResourceStoreController ||
+            $controller instanceof ResourceUpdateController) {
 
             $fields = parent::availableFields($request);
             $containers = $this->findAllContainers($fields);


### PR DESCRIPTION
Hi!

I was working with this package and I was using a custom field inside a ConditionalContainer. During resource creation everything worked as expected, but during resource update I was getting errors. Turned out that that custom field was added to the update query, even though it's defined with `->exceptOnForms()`.

This PR adds a check to see if a field is shown on update, and will not add it if not.

Hope it's helpful!